### PR TITLE
Allow template paths to be filtered

### DIFF
--- a/tmpl/button-row.php
+++ b/tmpl/button-row.php
@@ -20,7 +20,9 @@ $all_categories = 'all-categories' === $options['banner_options'];
 				 *
 				 * @var string The path to the cookie consent policy template.
 				 */
-				apply_filters( 'altis.consent.cookie_consent_policy_template_path', load_template( __DIR__ . '/cookie-consent-policy.php' ) );
+				$cookie_consent_policy_path = apply_filters( 'altis.consent.cookie_consent_policy_template_path', __DIR__ . '/cookie-consent-policy.php' );
+
+				load_template( $cookie_consent_policy_path );
 			?>
 		<?php endif; ?>
 	</div>

--- a/tmpl/button-row.php
+++ b/tmpl/button-row.php
@@ -14,7 +14,14 @@ $all_categories = 'all-categories' === $options['banner_options'];
 	<div class="cookie-consent-message">
 		<?php echo wp_kses_post( $banner_message ); ?>
 		<?php if ( $policy_page ) : ?>
-			<?php load_template( __DIR__ . '/cookie-consent-policy.php' ); ?>
+			<?php
+				/**
+				 * Allow the cookie consent policy template path to be overridden so it can be customized individually. This template displays the link to the cookie policy page, but only if a cookie policy page has been set.
+				 *
+				 * @var string The path to the cookie consent policy template.
+				 */
+				apply_filters( 'altis.consent.cookie_consent_policy_template_path', load_template( __DIR__ . '/cookie-consent-policy.php' ) );
+			?>
 		<?php endif; ?>
 	</div>
 

--- a/tmpl/consent-banner.php
+++ b/tmpl/consent-banner.php
@@ -9,7 +9,14 @@ $no_option_saved_message = sprintf(
 ?>
 
 <div id="cookie-consent-banner">
-	<?php load_template( __DIR__ . '/consent-updated.php' ); ?>
+	<?php
+	/**
+	 * Allow the consent updated template path to be overridden so it can be customized independently. This template displays the "preferences updated" messaging after they have been saved.
+	 *
+	 * @var string The path to the consent updated template.
+	 */
+	apply_filters( 'altis.consent.consent_updated_template_path', load_template( __DIR__ . '/consent-updated.php' ) );
+	?>
 	<div class="consent-banner">
 		<?php
 		if ( '' === $options['banner_options'] ) {
@@ -22,8 +29,19 @@ $no_option_saved_message = sprintf(
 				apply_filters( 'altis.consent.no_option_saved_message', $no_option_saved_message )
 			);
 		} else {
-			load_template( __DIR__ . '/cookie-preferences.php' );
-			load_template( __DIR__ . '/button-row.php' );
+			/**
+			 * Allow the cookie preferences template path to be overridden so it can be customized independently.
+			 *
+			 * @var string The path to the cookie preferences template.
+			 */
+			apply_filters( 'altis.consent.cookie_preferences_template_path', load_template( __DIR__ . '/cookie-preferences.php' ) );
+
+			/**
+			 * Allow the button row template path to be overridden so it can be customized independently. This is the main content template that includes the buttons and the messaging of the banner.
+			 *
+			 * @var string The path to the button row template.
+			 */
+			apply_filters( 'altis.consent.button_row_template_path', load_template( __DIR__ . '/button-row.php' ) );
 		}
 		?>
 	</div>

--- a/tmpl/consent-banner.php
+++ b/tmpl/consent-banner.php
@@ -40,7 +40,7 @@ $no_option_saved_message = sprintf(
 				 *
 				 * @var string The path to the cookie preferences template.
 				 */
-				$cookie_preferences_template_path( 'altis.consent.cookie_preferences_template_path', __DIR__ . '/cookie-preferences.php' );
+				$cookie_preferences_template_path = apply_filters( 'altis.consent.cookie_preferences_template_path', __DIR__ . '/cookie-preferences.php' );
 
 				load_template( $cookie_preferences_template_path );
 			}

--- a/tmpl/consent-banner.php
+++ b/tmpl/consent-banner.php
@@ -29,12 +29,14 @@ $no_option_saved_message = sprintf(
 				apply_filters( 'altis.consent.no_option_saved_message', $no_option_saved_message )
 			);
 		} else {
-			/**
-			 * Allow the cookie preferences template path to be overridden so it can be customized independently.
-			 *
-			 * @var string The path to the cookie preferences template.
-			 */
-			apply_filters( 'altis.consent.cookie_preferences_template_path', load_template( __DIR__ . '/cookie-preferences.php' ) );
+			if ( 'none' !== $banner_option ) {
+				/**
+				 * Allow the cookie preferences template path to be overridden so it can be customized independently.
+				 *
+				 * @var string The path to the cookie preferences template.
+				 */
+				apply_filters( 'altis.consent.cookie_preferences_template_path', load_template( __DIR__ . '/cookie-preferences.php' ) );
+			}
 
 			/**
 			 * Allow the button row template path to be overridden so it can be customized independently. This is the main content template that includes the buttons and the messaging of the banner.

--- a/tmpl/consent-banner.php
+++ b/tmpl/consent-banner.php
@@ -18,7 +18,9 @@ $no_option_saved_message = sprintf(
 	 *
 	 * @var string The path to the consent updated template.
 	 */
-	apply_filters( 'altis.consent.consent_updated_template_path', load_template( __DIR__ . '/consent-updated.php' ) );
+	$consent_updated_template_path = apply_filters( 'altis.consent.consent_updated_template_path', __DIR__ . '/consent-updated.php' );
+
+	load_template( $consent_updated_template_path );
 	?>
 	<div class="consent-banner">
 		<?php
@@ -38,7 +40,9 @@ $no_option_saved_message = sprintf(
 				 *
 				 * @var string The path to the cookie preferences template.
 				 */
-				apply_filters( 'altis.consent.cookie_preferences_template_path', load_template( __DIR__ . '/cookie-preferences.php' ) );
+				$cookie_preferences_template_path( 'altis.consent.cookie_preferences_template_path', __DIR__ . '/cookie-preferences.php' );
+
+				load_template( $cookie_preferences_template_path );
 			}
 
 			/**
@@ -46,7 +50,9 @@ $no_option_saved_message = sprintf(
 			 *
 			 * @var string The path to the button row template.
 			 */
-			apply_filters( 'altis.consent.button_row_template_path', load_template( __DIR__ . '/button-row.php' ) );
+			$button_row_template_path = apply_filters( 'altis.consent.button_row_template_path', __DIR__ . '/button-row.php' );
+
+			load_template( $button_row_template_path );
 		}
 		?>
 	</div>

--- a/tmpl/consent-banner.php
+++ b/tmpl/consent-banner.php
@@ -1,6 +1,9 @@
 <?php
+
+use Altis\Consent\Settings;
+
 $categories              = WP_CONSENT_API::$config->consent_categories();
-$options                 = get_option( 'cookie_consent_options' );
+$banner_option           = Settings\get_consent_option( 'banner_options' );
 $no_option_saved_message = sprintf(
 	// Translators: %s is the link to the admin Privacy setting page.
 	__( 'No consent option has been set. Please visit the <a href="%s">Privacy Settings page</a> and set the consent banner option.', 'altis-consent.' ),
@@ -19,7 +22,7 @@ $no_option_saved_message = sprintf(
 	?>
 	<div class="consent-banner">
 		<?php
-		if ( '' === $options['banner_options'] ) {
+		if ( '' === $banner_option ) {
 			echo wp_kses_post(
 				/**
 				 * Allow the no option saved message to be filtered.


### PR DESCRIPTION
This PR adds additional filters to allow individual template paths to be overridden.  This would enable project teams to use _some_ of the existing templates but create their own templates for other parts without rebuilding the entire banner.