### PR TITLE
Fix the allow-listed categories filter hook

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -63,7 +63,7 @@ function get_consented_categories() : array {
 	 *
 	 * @var array Array of always-allowed cookie categories.
 	 */
-	$allowlist = apply_filters( 'altis.consent.allowlisted_categories', [ 'functional', 'statistics-anonymous' ] );
+	$allowlist = apply_filters( 'altis.consent.always_allow_categories', [ 'functional', 'statistics-anonymous' ] );
 
 	foreach ( $categories as $category ) {
 		if ( in_array( $category, $allowlist, true ) ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -39,7 +39,7 @@ function enqueue_assets() {
 		 *
 		 * @var array An array of default categories to consent to automatically.
 		 */
-		'alwaysAllowCategories' => apply_filters( 'altis.consent.always_allow_categories', [ 'functional', 'statistics-anonymous' ] ),
+		'alwaysAllowCategories' => apply_filters( 'altis.consent.allowlisted_categories', [ 'functional', 'statistics-anonymous' ] ),
 	] );
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -39,7 +39,7 @@ function enqueue_assets() {
 		 *
 		 * @var array An array of default categories to consent to automatically.
 		 */
-		'alwaysAllowCategories' => apply_filters( 'altis.consent.allowlisted_categories', [ 'functional', 'statistics-anonymous' ] ),
+		'alwaysAllowCategories' => apply_filters( 'altis.consent.always_allow_categories', [ 'functional', 'statistics-anonymous' ] ),
 	] );
 }
 


### PR DESCRIPTION
Quick fix to the filter hook name so it matches the same thing we use elsewhere.

This change is already documented in the filter reference: https://github.com/humanmade/altis-consent/wiki/Altis-Consent-Filter-Reference