### PR TITLE
Get default banner message

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -387,16 +387,24 @@ function render_banner_options() {
 }
 
 /**
- * Render the banner message setting.
+ * Return the default banner message.
+ *
+ * @return string The default banner message.
  */
-function render_banner_message() {
+function get_default_banner_message() : string {
 	/**
 	 * Allow the default cookie banner message to be filtered.
 	 *
 	 * @var string $default_message The default cookie consent banner message.
 	 */
-	$default_message = apply_filters( 'altis.consent.default_banner_message', esc_html__( 'This site uses cookies to provide a better user experience.', 'altis-consent' ) );
-	$message         = get_consent_option( 'banner_message', $default_message );
+	return apply_filters( 'altis.consent.default_banner_message', esc_html__( 'This site uses cookies to provide a better user experience.', 'altis-consent' ) );
+}
+
+/**
+ * Render the banner message setting.
+ */
+function render_banner_message() {
+	$message = get_consent_option( 'banner_message', get_default_banner_message() );
 
 	// Render a TinyMCE editor for the banner message.
 	wp_editor( wp_kses_post( $message ), 'banner_message', [

--- a/tmpl/button-row.php
+++ b/tmpl/button-row.php
@@ -11,11 +11,7 @@ use Altis\Consent\Settings;
  * Get the consent options and set some specific default values.
  */
 $options        = get_option( 'cookie_consent_options', [] );
-$options = wp_parse_args( $options, [
-      'banner_message' => Settings\get_default_banner_message(),
-	'policy_page'    => false,
-	'banner-options' => 'none',
-] );
+$options        = wp_parse_args( $options, [
 	'banner_message' => Settings\get_default_banner_message(),
 	'policy_page'    => false,
 	'banner-options' => 'none',

--- a/tmpl/button-row.php
+++ b/tmpl/button-row.php
@@ -4,9 +4,19 @@
  *
  * @package Altis-Consent
  */
-$options        = get_option( 'cookie_consent_options' );
+
+use Altis\Consent\Settings;
+
+/**
+ * Get the consent options and set some specific default values.
+ */
+$options        = get_option( 'cookie_consent_options', [
+	'banner_message' => Settings\get_default_banner_message(),
+	'policy_page'    => false,
+	'banner-options' => 'none',
+] );
 $banner_message = $options['banner_message'];
-$policy_page    = $options['policy_page'] ?: false;
+$policy_page    = $options['policy_page'];
 $all_categories = 'all-categories' === $options['banner_options'];
 ?>
 

--- a/tmpl/button-row.php
+++ b/tmpl/button-row.php
@@ -10,7 +10,12 @@ use Altis\Consent\Settings;
 /**
  * Get the consent options and set some specific default values.
  */
-$options        = get_option( 'cookie_consent_options', [
+$options        = get_option( 'cookie_consent_options', [] );
+$options = wp_parse_args( $options, [
+      'banner_message' => Settings\get_default_banner_message(),
+	'policy_page'    => false,
+	'banner-options' => 'none',
+] );
 	'banner_message' => Settings\get_default_banner_message(),
 	'policy_page'    => false,
 	'banner-options' => 'none',


### PR DESCRIPTION
Adds a function that returns the default banner message.

When documenting the template files, I realized that a banner message would not display unless it was defined in the options already. Adding a function to return the banner message and moving the filter into there allows us to get the default banner message even if it hasn't been set in the options yet.