### PR TITLE
Add function to get cookie policy url

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -142,3 +142,27 @@ function should_display_banner() : bool {
 	 */
 	return (bool) apply_filters( 'altis.consent.should_display_banner', Settings\get_consent_option( 'display_banner', false ) );
 }
+
+/**
+ * Return the cookie policy page url.
+ *
+ * @return string The cookie policy page url.
+ */
+function get_cookie_policy_url() : string {
+	$cookie_policy_page_id  = Settings\get_consent_option( 'policy_page', 0 );
+
+	if ( 'page' !== get_post_type( $cookie_policy_page_id ) ) {
+		$cookie_policy_page_url = get_permalink( $cookie_policy_page_id );
+	} elseif ( ! $cookie_policy_page_id ) {
+		$cookie_policy_page_url = '';
+	} else {
+		$cookie_policy_page_url = get_page_uri( $cookie_policy_page_id );
+	}
+
+	/**
+	 * Allow the cookie policy page url to be filtered.
+	 *
+	 * @var string The cookie policy page url.
+	 */
+	return apply_filters( 'altis.consent.cookie_policy_url', $cookie_policy_page_url );
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -149,7 +149,7 @@ function should_display_banner() : bool {
  * @return string The cookie policy page url.
  */
 function get_cookie_policy_url() : string {
-	$cookie_policy_page_id  = Settings\get_consent_option( 'policy_page', 0 );
+	$cookie_policy_page_id = Settings\get_consent_option( 'policy_page', 0 );
 
 	if ( 'page' !== get_post_type( $cookie_policy_page_id ) ) {
 		$cookie_policy_page_url = get_permalink( $cookie_policy_page_id );

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -149,7 +149,7 @@ function should_display_banner() : bool {
  * @return string The cookie policy page url.
  */
 function get_cookie_policy_url() : string {
-	$cookie_policy_page_id = Settings\get_consent_option( 'policy_page', 0 );
+	$cookie_policy_page_id = (int) Settings\get_consent_option( 'policy_page', 0 );
 
 	// Make sure the cookie policy page ID is an actual page.
 	if ( 'page' === get_post_type( $cookie_policy_page_id ) ) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -151,12 +151,11 @@ function should_display_banner() : bool {
 function get_cookie_policy_url() : string {
 	$cookie_policy_page_id = Settings\get_consent_option( 'policy_page', 0 );
 
-	if ( 'page' !== get_post_type( $cookie_policy_page_id ) ) {
-		$cookie_policy_page_url = get_permalink( $cookie_policy_page_id );
-	} elseif ( ! $cookie_policy_page_id ) {
-		$cookie_policy_page_url = '';
-	} else {
+	// Make sure the cookie policy page ID is an actual page.
+	if ( 'page' === get_post_type( $cookie_policy_page_id ) ) {
 		$cookie_policy_page_url = get_page_uri( $cookie_policy_page_id );
+	} else {
+		$cookie_policy_page_url = '';
 	}
 
 	/**


### PR DESCRIPTION
WordPress core has `get_privacy_policy_url` so if we have a cookie policy page that uses a similar functionality, we should also have a `get_cookie_policy_url` function.

This PR also adds a `altis.consent.coolie_policy_url` filter. 

Both documented in the Wiki
https://github.com/humanmade/altis-consent/wiki/Altis-Consent-Public-Functions#get_cookie_policy_url
https://github.com/humanmade/altis-consent/wiki/Altis-Consent-Filter-Reference#altisconsentcookie_policy_url