### PR TITLE
use the get_cookie_policy_url function instead of get_option

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -149,13 +149,12 @@ function should_display_banner() : bool {
  * @return string The cookie policy page url.
  */
 function get_cookie_policy_url() : string {
-	$cookie_policy_page_id = (int) Settings\get_consent_option( 'policy_page', 0 );
+	$cookie_policy_page_url = '';
+	$cookie_policy_page_id  = (int) Settings\get_consent_option( 'policy_page', 0 );
 
 	// Make sure the cookie policy page ID is an actual page.
 	if ( 'page' === get_post_type( $cookie_policy_page_id ) ) {
 		$cookie_policy_page_url = get_page_uri( $cookie_policy_page_id );
-	} else {
-		$cookie_policy_page_url = '';
 	}
 
 	/**

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -152,8 +152,8 @@ function get_cookie_policy_url() : string {
 	$cookie_policy_page_url = '';
 	$cookie_policy_page_id  = (int) Settings\get_consent_option( 'policy_page', 0 );
 
-	// Make sure the cookie policy page ID is an actual page.
-	if ( 'page' === get_post_type( $cookie_policy_page_id ) ) {
+	// Make sure the cookie policy page ID is an actual page and it's public.
+	if ( get_post_type( $cookie_policy_page_id ) === 'page' && get_post_status( $cookie_policy_page_id ) === 'publish' ) {
 		$cookie_policy_page_url = get_page_uri( $cookie_policy_page_id );
 	}
 

--- a/tmpl/cookie-consent-policy.php
+++ b/tmpl/cookie-consent-policy.php
@@ -5,12 +5,13 @@
  * @package Altis-Consent
  */
 
-$options     = get_option( 'cookie_consent_options' );
-$policy_page = $options['policy_page'];
+use Altis\Consent\Settings;
+
+$policy_page = (int) Settings\get_consent_option( 'policy_page' );
 ?>
 
 <div class="cookie-consent-policy">
-	<a href="<?php echo esc_url( get_permalink( (int) $policy_page ) ); ?>">
+	<a href="<?php echo esc_url( get_permalink( $policy_page ) ); ?>">
 		<?php
 		echo wp_kses_post(
 			/**

--- a/tmpl/cookie-consent-policy.php
+++ b/tmpl/cookie-consent-policy.php
@@ -5,13 +5,11 @@
  * @package Altis-Consent
  */
 
-use Altis\Consent\Settings;
-
-$policy_page = (int) Settings\get_consent_option( 'policy_page' );
+use Altis\Consent;
 ?>
 
 <div class="cookie-consent-policy">
-	<a href="<?php echo esc_url( get_permalink( $policy_page ) ); ?>">
+	<a href="<?php echo esc_url( Consent\get_cookie_policy_url() ); ?>">
 		<?php
 		echo wp_kses_post(
 			/**


### PR DESCRIPTION
Like it says on the tin. Use the helper function rather than `get_option`.

`get_cookie_policy_url` is documented [here](https://github.com/humanmade/altis-consent/wiki/Altis-Consent-Public-Functions#get_cookie_policy_url) and does the same thing that [`get_privacy_policy_url`](http://developer.wordpress.org/reference/functions/get_privacy_policy_url/) does.