### PR TITLE
Use path instead of URL for generating version

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -44,7 +44,7 @@ function enqueue_assets() {
 		$js = plugin_dir_url( __DIR__ ) . 'assets/js/main.js';
 
 		// Break the cache on local.
-		$ver .= '-' . filemtime( $css );
+		$ver .= '-' . filemtime( plugin_dir_path( __DIR__ ) . 'dist/css/styles.css' );
 	}
 
 	wp_enqueue_script( 'altis-consent', $js, [], $ver, true );


### PR DESCRIPTION
This was trying to do `filemtime()` on a URL, which won't work correctly.