### PR TITLE
cookie prefs bug

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -126,7 +126,7 @@ function validate_consent_item( string $item, string $item_type ) {
 	}
 
 	// Use a variable function name to check the matching item type.
-	$haystack = 'consent_' . $item_type;
+	$haystack = __NAMESPACE__ . '\\consent_' . $item_type;
 	if ( in_array( $item, $haystack(), true ) ) {
 		return $item;
 	}

--- a/tmpl/cookie-preferences.php
+++ b/tmpl/cookie-preferences.php
@@ -14,7 +14,7 @@ $categories = Consent\consent_categories();
 	<?php
 	foreach ( $categories as $category ) {
 		// Validate the consent category.
-		if ( ! Consent\validate_consent_item( $category, 'category' ) ) {
+		if ( ! Consent\validate_consent_item( $category, 'categories' ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
2 issues were preventing the cookie categories from displaying in the cookie preferences panel in the consent banner:

1. when `validate_consent_item` was called, `category` was being passed as the `$item_type` but the value needed to be `categories`.
2. the variable function called inside `validate_consent_item` needed to have the namespace attached.

fixes #34

**Question:** Should we support singular values for the `$item_type`s? Right now, it's based entirely on the function names itself (e.g. `consent_categories`, `consent_types`, `consent_values`) because those are the functions that return all values of those types. But it possibly makes more sense as a developer to think in singular terms ("validate this _item_ which is a _category_" as opposed to "validate this _item_ which is in _categories_"). The downside is having to add additional logic to change a singular value passed (e.g. `category`) to plural. E.g.:

```php
if ( in_array( $item_type, [ 'category', 'value', 'type' ] ) ) {
    switch ( $item_type ) { 
        case 'category' : 
            $item_type = 'categories';
            break;
        case 'value' : 
            $item_type = 'values';
            break;
        case 'type' : 
            $item_type = 'types';
            break;
    }
}
```

Is it worth the extra overhead for being more developer friendly?

Other options are renaming the helper functions (e.g. `consent_category` instead of `consent_categories`), but that makes less sense given that we get multiple values, or creating new functions that are either wrapper functions (just calling the same `consent_` function) with a singular name, or do some other, related processing (like maybe taking care of an `in_array` check). I still think it would add more processing overhead than the way it's currently built.