### PR TITLE
remove the consent api dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "description": "Privacy and consent module for Altis",
     "type": "package",
     "require": {
-        "php": ">=7.1",
-        "altis/consent-api": "^1.0.2"
+        "php": ">=7.1"
     },
     "require-dev": {
         "humanmade/coding-standards": "^1.1.0"


### PR DESCRIPTION
removes `altis/consent-api` from the composer file -- loaded in `altis/core` in https://github.com/humanmade/altis-core/pull/107