### PR TITLE
add documentation for the consent api event to listen for

### DIFF
--- a/docs/developer-docs/JavaScript-Reference.md
+++ b/docs/developer-docs/JavaScript-Reference.md
@@ -5,9 +5,11 @@ Event to listen for consent changes.
 ### Example
 
 ```js
+// Listen for changes in consent statuses.
 document.addEventListener( 'wp_listen_for_consent_change', function ( e ) {
   var changedConsentCategory = e.detail;
   for ( var key in changedConsentCategory ) {
+    // Check if marketing cookies are allowed.
     if ( e.detail.marketing && e.detail.marketing === 'allow' ) {
       console.log( 'just given consent, track user data' )
     }

--- a/docs/developer-docs/JavaScript-Reference.md
+++ b/docs/developer-docs/JavaScript-Reference.md
@@ -8,7 +8,7 @@ Event to listen for consent changes.
 document.addEventListener( 'wp_listen_for_consent_change', function ( e ) {
   var changedConsentCategory = e.detail;
   for ( var key in changedConsentCategory ) {
-    if ( changedConsentCategory.hasOwnProperty( key ) ) {
+    if ( e.detail.marketing && e.detail.marketing === 'allow' ) {
       if ( key === 'marketing' && changedConsentCategory[key] === 'allow' ) {
         console.log( 'just given consent, track user data' )
       }

--- a/docs/developer-docs/JavaScript-Reference.md
+++ b/docs/developer-docs/JavaScript-Reference.md
@@ -9,9 +9,7 @@ document.addEventListener( 'wp_listen_for_consent_change', function ( e ) {
   var changedConsentCategory = e.detail;
   for ( var key in changedConsentCategory ) {
     if ( e.detail.marketing && e.detail.marketing === 'allow' ) {
-      if ( key === 'marketing' && changedConsentCategory[key] === 'allow' ) {
-        console.log( 'just given consent, track user data' )
-      }
+      console.log( 'just given consent, track user data' )
     }
   }
 });

--- a/docs/developer-docs/JavaScript-Reference.md
+++ b/docs/developer-docs/JavaScript-Reference.md
@@ -1,3 +1,22 @@
+## `wp_listen_for_consent_change`
+
+Event to listen for consent changes.
+
+### Example
+
+```js
+document.addEventListener( 'wp_listen_for_consent_change', function ( e ) {
+  var changedConsentCategory = e.detail;
+  for ( var key in changedConsentCategory ) {
+    if ( changedConsentCategory.hasOwnProperty( key ) ) {
+      if ( key === 'marketing' && changedConsentCategory[key] === 'allow' ) {
+        console.log( 'just given consent, track user data' )
+      }
+    }
+  }
+});
+```
+
 **Note:** All Altis Consent JavaScript functions are in the `Altis.Consent` namespace.
 
 ## `Altis.Consent.has`


### PR DESCRIPTION
We need to be responsible for providing this documentation if we expect people to not dig down into the js api for this information.

This adds some information about the `wp_listen_for_consent_change` event that developers can listen to for a consent change, and copies the example code provided by the original consent api.