### PR TITLE
Fix broken cookie policy link

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -147,7 +147,7 @@ function get_cookie_policy_url() : string {
 
 	// Make sure the cookie policy page ID is an actual page and it's public.
 	if ( get_post_type( $cookie_policy_page_id ) === 'page' && get_post_status( $cookie_policy_page_id ) === 'publish' ) {
-		$cookie_policy_page_url = get_page_uri( $cookie_policy_page_id );
+		$cookie_policy_page_url = get_page_link( $cookie_policy_page_id );
 	}
 
 	/**


### PR DESCRIPTION
use `get_page_link`; `get_page_uri` only returns the slug. `get_page_link` returns the full url