### PR TITLE
Use the latest version of the consent api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "package",
     "require": {
         "php": ">=7.1",
-        "altis/consent-api": "^1.0.4"
+        "altis/consent-api": "^1.0.5"
     },
     "require-dev": {
         "humanmade/coding-standards": "^1.1.0"


### PR DESCRIPTION
Updates the version of the `altis/consent-api` to the latest