### PR TITLE
Swap close dashicon for text label

### DIFF
--- a/tmpl/consent-updated.php
+++ b/tmpl/consent-updated.php
@@ -11,6 +11,6 @@
 		<span class="preferences-updated-message">
 			<?php echo wp_kses_post( apply_filters( 'altis.consent.preferences_updated_message', __( 'Cookie preferences updated.', 'altis-consent' ) ) ); ?>
 		</span>
-		<button class="close-message" id="consent-close-updated-message"><span class="dashicons dashicons-no-alt"></span></button>
+		<button class="close-message" id="consent-close-updated-message"><?php esc_html_e( 'Close', 'altis-consent' ); ?></button>
 	</p>
 </div>


### PR DESCRIPTION
This fixes the lack of dashicons being loaded when someone is not signed in as well as fixes the accessibility of the banner close button due the lack of any text content or a title attribute.

Fixes #56