### PR TITLE
Cookie preference label not clickable.

### DIFF
--- a/tmpl/cookie-preferences.php
+++ b/tmpl/cookie-preferences.php
@@ -25,7 +25,7 @@ $categories = Consent\consent_categories();
 		?>
 
 		<label for="cookie-preference-<?php echo esc_attr( $category ); ?>">
-			<input type="checkbox" name="cookie-preferences[<?php echo esc_attr( $category ); ?>]" class="category-input" value="<?php echo esc_attr( $category ); ?>"
+			<input type="checkbox" name="cookie-preferences[<?php echo esc_attr( $category ); ?>]" class="category-input" value="<?php echo esc_attr( $category ); ?>" id="cookie-preference-<?php echo esc_attr( $category ); ?>"
 				<?php if ( 'functional' === $category ) : ?>
 					checked="checked" disabled="disabled"
 				<?php endif; ?>


### PR DESCRIPTION
In Chrome, if you click a cookie preference label, it does not toggle the checkbox. It only works if you click the actual input. 

This should work because the label wraps both the text and input, BUT because it is given a `for` attribute, but that doesn't reference an input by ID, it breaks. 

Solution is either to give the input an ID, or to remove the `for` attribute. I figured adding the ID was best just in case someone had styled the label using an attribute selector.