### PR TITLE
Displaying default cookie categories.

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -194,15 +194,10 @@ function get_category_label( string $category ) : string {
  * @return array Returns always allowed categories.
  */
 function get_always_allowed_categories() {
-	$allowed = apply_filters( 'altis.consent.always_allow_categories', [] );
-	if ( ! empty( $allowed ) ) {
-		return $allowed;
-	}
-
-	$default = [
-		'functional',
-		'statistics-anonymous',
-	];
-
-	return $default;
+	/**
+	 * Filter the default cookie categories.
+	 *
+	 * @param array $categories The default always allowed consent categories.
+	 */
+	return apply_filters( 'altis.consent.always_allow_categories', [ 'functional', 'statistics-anonymous' ] );
 }

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -194,7 +194,7 @@ function get_category_label( string $category ) : string {
  * @return array Returns always allowed categories.
  */
 function get_always_allowed_categories() {
-	$allowed = apply_filters( 'altis.consent.always_allow_categories',[] );
+	$allowed = apply_filters( 'altis.consent.always_allow_categories', [] );
 	if ( ! empty( $allowed ) ) {
 		return $allowed;
 	}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -194,7 +194,6 @@ function get_category_label( string $category ) : string {
  * @return array Returns always allowed categories.
  */
 function get_always_allowed_categories() {
-
 	$allowed = apply_filters( 'altis.consent.always_allow_categories',[] );
 	if ( ! empty( $allowed ) ) {
 		return $allowed;

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -188,7 +188,6 @@ function get_category_label( string $category ) : string {
 	return consent_category_labels()[ $category ] ?? '';
 }
 
-
 /**
  * Retrieve the always allowed categories.
  *

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -187,3 +187,24 @@ function get_cookie_policy_url() : string {
 function get_category_label( string $category ) : string {
 	return consent_category_labels()[ $category ] ?? '';
 }
+
+
+/**
+ * Retrieve the always allowed categories.
+ *
+ * @return array Returns always allowed categories.
+ */
+function get_always_allowed_categories() {
+
+	$allowed = apply_filters( 'altis.consent.always_allow_categories',[] );
+	if ( ! empty( $allowed ) ) {
+		return $allowed;
+	}
+
+	$default = [
+		'functional',
+		'statistics-anonymous',
+	];
+
+	return $default;
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -67,6 +67,7 @@ function enqueue_assets() {
 
 	wp_enqueue_script( 'altis-consent', $js, [ 'altis-consent-api' ], $ver, true );
 	wp_enqueue_style( 'altis-consent', $css, [], $ver, 'screen' );
+
 	wp_localize_script( 'altis-consent', 'altisConsent', [
 		/**
 		 * Allow the array of categories that are always consented to be filtered.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,8 @@ function bootstrap() {
 		add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 		add_action( 'wp_footer', __NAMESPACE__ . '\\load_consent_banner' );
 	}
+
+	add_action( 'altis.consent.always_allow_categories', __NAMESPACE__ . '\\always_allow_categories', 20 );
 }
 
 /**
@@ -73,11 +75,32 @@ function enqueue_assets() {
 		 *
 		 * @var array An array of default categories to consent to automatically.
 		 */
-		'alwaysAllowCategories' => apply_filters( 'altis.consent.always_allow_categories', [ 'functional', 'statistics-anonymous' ] ),
+		'alwaysAllowCategories' => apply_filters( 'altis.consent.always_allow_categories', [] ),
 		'cookiePrefix' => cookie_prefix(),
 		'types' => consent_types(),
 		'categories' => consent_categories(),
 		'values' => consent_values(),
 		'shouldDisplayBanner' => should_display_banner(),
 	] );
+}
+
+/**
+ * Retrieve the always allowed categories
+ *
+ * @param array $allowed
+ * @return array if $allowed is empty, return $default
+ */
+function always_allow_categories( array $allowed ) {
+
+	if ( !empty( $allowed ) ) {
+		return $allowed;
+	}
+
+	$default = [
+		'functional',
+		'statistics-anonymous'
+	];
+
+	return $default;
+
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -41,7 +41,6 @@ function bootstrap() {
 		add_action( 'wp_footer', __NAMESPACE__ . '\\load_consent_banner' );
 	}
 
-	add_action( 'altis.consent.always_allow_categories', __NAMESPACE__ . '\\always_allow_categories', 20 );
 }
 
 /**
@@ -68,39 +67,18 @@ function enqueue_assets() {
 
 	wp_enqueue_script( 'altis-consent', $js, [ 'altis-consent-api' ], $ver, true );
 	wp_enqueue_style( 'altis-consent', $css, [], $ver, 'screen' );
-
 	wp_localize_script( 'altis-consent', 'altisConsent', [
 		/**
 		 * Allow the array of categories that are always consented to be filtered.
 		 *
 		 * @var array An array of default categories to consent to automatically.
 		 */
-		'alwaysAllowCategories' => apply_filters( 'altis.consent.always_allow_categories', [] ),
+
+		'alwaysAllowCategories' => get_always_allowed_categories(),
 		'cookiePrefix' => cookie_prefix(),
 		'types' => consent_types(),
 		'categories' => consent_categories(),
 		'values' => consent_values(),
 		'shouldDisplayBanner' => should_display_banner(),
 	] );
-}
-
-/**
- * Retrieve the always allowed categories
- *
- * @param array $allowed
- * @return array if $allowed is empty, return $default
- */
-function always_allow_categories( array $allowed ) {
-
-	if ( !empty( $allowed ) ) {
-		return $allowed;
-	}
-
-	$default = [
-		'functional',
-		'statistics-anonymous'
-	];
-
-	return $default;
-
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,7 +40,6 @@ function bootstrap() {
 		add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
 		add_action( 'wp_footer', __NAMESPACE__ . '\\load_consent_banner' );
 	}
-
 }
 
 /**
@@ -74,7 +73,6 @@ function enqueue_assets() {
 		 *
 		 * @var array An array of default categories to consent to automatically.
 		 */
-
 		'alwaysAllowCategories' => get_always_allowed_categories(),
 		'cookiePrefix' => cookie_prefix(),
 		'types' => consent_types(),

--- a/tmpl/cookie-preferences.php
+++ b/tmpl/cookie-preferences.php
@@ -12,14 +12,15 @@ $categories = Consent\consent_categories();
 
 <div class="cookie-preferences">
 	<?php
+	$alwaysAllowedCategories = apply_filters( 'altis.consent.always_allow_categories', [] );
 	foreach ( $categories as $category ) {
 		// Validate the consent category.
 		if ( ! Consent\validate_consent_item( $category, 'categories' ) ) {
 			continue;
 		}
 
-		// Skip anonymous statistics category, don't need to ask permission explicitly.
-		if ( 'statistics-anonymous' === $category ) {
+		// Ensure the functional category always shows, hide the always allowed categories
+		if ( 'functional' != $category && in_array( $category, $alwaysAllowedCategories, true ) ) {
 			continue;
 		}
 		?>

--- a/tmpl/cookie-preferences.php
+++ b/tmpl/cookie-preferences.php
@@ -12,7 +12,6 @@ $categories = Consent\consent_categories();
 
 <div class="cookie-preferences">
 	<?php
-
 	foreach ( $categories as $category ) {
 		// Validate the consent category.
 		if ( ! Consent\validate_consent_item( $category, 'categories' ) ) {

--- a/tmpl/cookie-preferences.php
+++ b/tmpl/cookie-preferences.php
@@ -12,15 +12,15 @@ $categories = Consent\consent_categories();
 
 <div class="cookie-preferences">
 	<?php
-	$alwaysAllowedCategories = apply_filters( 'altis.consent.always_allow_categories', [] );
+
 	foreach ( $categories as $category ) {
 		// Validate the consent category.
 		if ( ! Consent\validate_consent_item( $category, 'categories' ) ) {
 			continue;
 		}
 
-		// Ensure the functional category always shows, hide the always allowed categories
-		if ( 'functional' != $category && in_array( $category, $alwaysAllowedCategories, true ) ) {
+		// Ensure the functional category always shows, hide the always allowed categories.
+		if ( 'functional' !== $category && in_array( $category, Consent\get_always_allowed_categories(), true ) ) {
 			continue;
 		}
 		?>


### PR DESCRIPTION
#### Issue
Removing `statistics-anonymous` from the default categories, doesn't give the user the option opt-in.

#### Fix
When removing `statistics-anonymous` from being in the default cookies category, this PR allows `statistics-anonymous` to show as an option that a user can opt-in for.

Related issue #88 